### PR TITLE
initialize obj in cors if-else statement

### DIFF
--- a/index.js
+++ b/index.js
@@ -156,6 +156,7 @@ function cors (opts) {
         obj[key] = _handler
       })
     } else {
+      var obj = {}
       var _handler = toCors(handler)
       obj.options = _handler
       obj.get = _handler


### PR DESCRIPTION
Given the current setup, handler errors out with:

```bash
/Users/lrlna/developer/merry/index.js:161
      obj.options = _handler
                  ^

TypeError: Cannot set property 'options' of undefined
    at /Users/lrlna/developer/merry/index.js:161:19
```

when working with a single handler. We need to set an obj before appending `options` and `get` :sparkles: :v: