### PR TITLE
res.statusCode = 500 for default error handler

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ Merry.prototype.router = function (opts, routes) {
       // val should ideally be a stream already, but if it's not we got you bae
       handler(req, res, ctx, function (err, val) {
         if (err) {
-          res.statusCode = err.statusCode || res.statusCode || 500
+          res.statusCode = err.statusCode || 500
           if ((res.statusCode / 100) === 4) {
             self.log.warn(err)
             return res.end(JSON.stringify({ message: err }))

--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ Merry.prototype.router = function (opts, routes) {
       // val should ideally be a stream already, but if it's not we got you bae
       handler(req, res, ctx, function (err, val) {
         if (err) {
-          res.statusCode = err.statusCode || 500
+          res.statusCode = err.statusCode || (res.statusCode >= 400 ? res.statusCode : 500)
           if ((res.statusCode / 100) === 4) {
             self.log.warn(err)
             return res.end(JSON.stringify({ message: err }))


### PR DESCRIPTION
node sets `res.statusCode` to 200 by default so 500 was never set even in the default error handler. I think an error should default to 500 even if it means overwriting `res.statusCode`