### PR TITLE
done(err) when err.output.payload has been modified to string

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,7 +76,7 @@ Merry.prototype.router = function (opts, routes) {
           var payload = err.output.payload
           if (err.data) payload.data = err.data
           var body = null
-          if (payload instanceof String) body = payload
+          if (typeof payload == 'string') body = payload
           else body = stringify(payload)
 
           var statusCode = err.output.statusCode ||

--- a/index.js
+++ b/index.js
@@ -75,7 +75,9 @@ Merry.prototype.router = function (opts, routes) {
 
           var payload = err.output.payload
           if (err.data) payload.data = err.data
-          var body = stringify(payload)
+          var body = null
+          if (payload instanceof String) body = payload
+          else body = stringify(payload)
 
           var statusCode = err.output.statusCode ||
             (res.statusCode >= 400 ? res.statusCode : 500)


### PR DESCRIPTION
When err returned through done(err) callback has been modified to a non-object such as a string the use of JSON.stringify() will encapsulate the string in extra quotations. For example if middleware modify the err.output.payload to be in XML format as type string the HTTP returned payload will include extra quotes breaking XML formatting and likely external app parsing.

Also consider adding http 'content-type' headers when outputting errors assuming that isn't against some standard.

done() handler correctly identifies this case when being called without err on line 96;
        if (isStream(val)) {
          stream = val
        } else if (typeof val === 'object') {
          res.setHeader('Content-Type', 'application/json')
          stream = fromString(stringify(val))
        } else if (typeof val === 'string') {
          stream = fromString(val)
        }