### PR TITLE
add gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,37 @@ function myCoolEndpoint (req, res, ctx, done) {
 }
 ```
 
+### Middleware Gateway
+An alternate way of consuming middleware is through `merry.gateway`. This
+creates an object on which you can set values, which might result in something
+slightly more readable when consuming lots of middleware.
+
+```js
+var merry = require('merry')
+
+var gate = merry.gateway()
+var app = merry()
+app.router([
+  ['/foo', {
+    get: gate({
+      schema: fs.readFileSync(path.join(__dirname, 'schemas/my-cool-schema')),
+      handler: require('./handlers/my-cool-handler')
+    })
+  }]
+]).listen(8080)
+```
+
+If you want to pass custom middleware, the gateway constructor can take an
+array of middleware. By default this is applied _after_ the built-in
+middleware. You can change the order of arguments by passing the order
+argument.
+
+```js
+var gate = merry.gateway({
+  middleware: [ require('my-mw'), require('other-mw') ]
+})
+```
+
 ## API
 ### app = merry(opts)
 Create a new instance of `merry`. Takes optional opts:
@@ -407,7 +438,7 @@ Create a naive `/404` handler that can be passed into a path.
 Add CORS support for handlers. Adds an handler for the HTTP `OPTIONS` method to
 catch preflight requests.
 
-### merry.middleware(handlers)
+### routeHandler = merry.middleware(handlers)
 Takes an array of handler functions. Each handler has a signature of
 `handler(req, res, ctx, done)`. `ctx` is an object onto which data can be
 attached. The `ctx` object is shared from one handler onto the other. If an
@@ -435,6 +466,17 @@ content.
 ### merry.parse.text(req, handler(err, text))
 Parse text in request body. Returns a string. You can alternativel use an alias
 of `merry.parse.string`.
+
+### gateway = merry.gateway(opts)
+Create a new gateway opts. By default includes all middleware exposed by
+`merry.middleware`. Takes the following opts:
+- __opts.middleware:__ Pass in an object containing additional middleware.
+- __opts.order:__ Specify the order in which the middleware must be applied.
+  Should be an array of strings. Defaults to whatever `Object.keys` returns.
+
+### routeHandler = gateway(opts)
+Create new routeHandler from a `gateway` instance. `opts` is configuration for
+the middleware that's used.
 
 ## Installation
 ```sh

--- a/gateway.js
+++ b/gateway.js
@@ -1,0 +1,38 @@
+var mutate = require('xtend/mutable')
+var assert = require('assert')
+var middleware = require('./middleware')
+
+module.exports = gateway
+
+// Create an API gateway
+// obj -> fn(obj) -> fn
+function gateway (opts) {
+  opts = opts || {}
+
+  assert.equal(typeof opts, 'object', 'merry.gateway: opts should be type object')
+
+  // apply built-in middleware & user middleware
+  var mw = {}
+  mutate(mw, middleware)
+  if (opts.middleware) mutate(mw, opts.middleware)
+
+  // Use a buch of config to create a router handler from middleware
+  return function (methods) {
+    assert.equal(typeof methods, 'object', 'merry.gateway: methods should be type object')
+    assert.equal(typeof methods.handler, 'function', 'merry.gateway: methods.handler should be type function')
+
+    var _mw = []
+    var keys = opts.order || Object.keys(methods)
+    for (var i = 0, len = keys.length; i < len; i++) {
+      var key = keys[i]
+      var handler = mw[key]
+      var config = methods[key]
+
+      if (key === 'handler') continue
+      _mw.push(handler(config))
+    }
+
+    _mw.push(methods.handler)
+    return middleware(_mw)
+  }
+}

--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ Merry.env = envobj
 Merry.cors = cors
 
 Merry.middleware = require('./middleware')
+Merry.gateway = require('./gateway')
 Merry.error = require('./error')
 Merry.parse = require('./parse')
 

--- a/middleware.js
+++ b/middleware.js
@@ -13,8 +13,10 @@ function middleware (arr) {
   assert.ok(arr.length >= 1, 'merry.middleware: arr should contain at least one handler')
 
   var final = arr.pop()
+  routeHandler._middleware = arr
+  return routeHandler
 
-  return function (req, res, ctx, done) {
+  function routeHandler (req, res, ctx, done) {
     mapLimit(arr, 1, iterator, function (err) {
       if (err) return done(err)
       final(req, res, ctx, done)

--- a/test/gateway.js
+++ b/test/gateway.js
@@ -1,0 +1,81 @@
+var tape = require('tape')
+
+var gateway = require('../').gateway
+
+var schema = `{
+  "type": "object",
+  "properties": {
+    "hello": { "type": "string" }
+  }
+}`
+
+tape('gateway', function (t) {
+  t.test('should assert input types', function (t) {
+    t.plan(1)
+    t.throws(gateway.bind(null, 123), /object/)
+  })
+
+  t.test('should create a routeHandler', function (t) {
+    t.plan(1)
+    var gw = gateway()
+    var handler = gw({
+      handler: noop,
+      schema: schema
+    })
+    t.equal(handler._middleware.length, 1, 'queued 1 middleware')
+  })
+
+  t.test('should allow passing custom middleware', function (t) {
+    t.plan(1)
+    function custom () {
+      return customInner
+    }
+
+    function customInner () {}
+
+    var gw = gateway({
+      middleware: { foo: custom }
+    })
+
+    var handler = gw({
+      handler: noop,
+      foo: 'bar'
+    })
+    t.equal(handler._middleware[0], customInner, 'allows custom middleware')
+  })
+
+  t.test('should allow specifying an execution order', function (t) {
+    t.plan(2)
+
+    function customInner () {}
+    function custom () {
+      return customInner
+    }
+
+    var gw = gateway({
+      middleware: { foo: custom },
+      order: [ 'foo', 'schema' ]
+    })
+
+    var handler = gw({
+      schema: schema,
+      handler: noop,
+      foo: 'bar'
+    })
+    t.equal(handler._middleware[0], customInner, 'allows custom middleware')
+
+    var gw2 = gateway({
+      middleware: { foo: custom },
+      order: [ 'schema', 'foo' ]
+    })
+
+    var handler2 = gw2({
+      schema: schema,
+      handler: noop,
+      foo: 'bar'
+    })
+    t.equal(handler2._middleware[1], customInner, 'allows custom middleware')
+  })
+})
+
+function noop () {}


### PR DESCRIPTION
Implement `merry.gateway`, an alternative way of consuming middleware. Closes https://github.com/yoshuawuyts/merry/issues/44. Thanks!