### PR TITLE
implement plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@
 - [Encoders](#encoders)
 - [Parsers](#parsers)
 - [Middleware](#middleware)
+- [Plugins](#plugins)
 - [API](#api)
 - [Installation](#installation)
 - [See Also](#see-also)
@@ -356,6 +357,20 @@ var gate = merry.gateway({
 })
 ```
 
+## Plugins
+Plugins provide a way to access framework internals in a clean way. You can
+register plugins through `app.use()`.
+
+```js
+var app = merry()
+app.use({
+  onRequest: function (req, res, done) {
+    res.statusCode = 401   // all statusCodes will now default to 401
+    done()
+  }
+})
+```
+
 ## API
 ### app = merry(opts)
 Create a new instance of `merry`. Takes optional opts:
@@ -410,6 +425,14 @@ function handleRoute (req, res, ctx, done) {
   done(null, 'hello planet')
 }
 ```
+
+### app.use(plugin)
+Register a plugin on the merry instance. A plugin is an object where the
+following values are possible:
+- __onRequest(req, res, done):__ called before a request is passed into the
+  router. `done()` can be called when the handler is done, and ready to pass
+  control to the next handler (or router if there are no handlers left). If the
+  request is terminated inside the handler, `done()` should not be called.
 
 ### error = merry.error(obj)
 Create a new HTTP error from an object. Expects a `.statusCode` and a `.message`

--- a/test/index.js
+++ b/test/index.js
@@ -52,6 +52,43 @@ tape('http handlers', function (t) {
       })
     })
   })
+
+  t.test('should call the onRequest hook', function (t) {
+    t.plan(6)
+    var app = merry({ logStream: devnull() })
+    var index = 0
+
+    app.use({
+      onRequest: function (req, res, done) {
+        t.pass(++index, 1, 'first onRequest was called')
+        done()
+      }
+    })
+
+    app.use({
+      onRequest: function (req, res, done) {
+        t.equal(++index, 2, 'second onRequest was called')
+        res.end()
+        setTimeout(done, 100)
+      }
+    })
+
+    app.router(['/', function (req, res, ctx, done) {
+      t.equal(++index, 3, 'done was called')
+      t.pass('finished')
+    }])
+
+    var server = http.createServer(app.start())
+    server.listen(function () {
+      var port = getPort(server)
+      var uri = 'http://localhost:' + port
+      request(uri, function (err, req) {
+        t.ifError(err, 'no err')
+        t.equal(req.statusCode, 200, 'status is ok')
+        server.close()
+      })
+    })
+  })
 })
 
 tape('status code', function (t) {
@@ -167,6 +204,14 @@ tape('encoders', function (t) {
     }])
     var server = http.createServer(app.start())
     performGet(server, t)
+  })
+})
+
+tape('plugins', function (t) {
+  t.test('should assert input types', function (t) {
+    t.plan(1)
+    var app = merry()
+    t.throws(app.use.bind(app), /object/)
   })
 })
 


### PR DESCRIPTION
Implements plugins that can be used through `app.use()`. Initially only allows to wrap requests before they're passed into the router, but can be expanded to do more in the future. Closes #72. Thanks!